### PR TITLE
gemfile.lock内の不要なコードを削除

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,9 +78,6 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 2.9.2, < 3)
       sassc-rails (>= 2.0.0)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
     builder (3.2.4)
     capybara (3.39.0)
       addressable
@@ -93,8 +90,6 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
-    cssbundling-rails (1.1.2)
-      railties (>= 6.0.0)
     date (3.3.3)
     debug (1.7.2)
       irb (>= 1.5.0)
@@ -147,11 +142,6 @@ GEM
       racc (~> 1.4)
     pg (1.5.3)
     popper_js (2.11.7)
-    propshaft (0.7.0)
-      actionpack (>= 7.0.0)
-      activesupport (>= 7.0.0)
-      rack
-      railties (>= 7.0.0)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -214,6 +204,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.3-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -249,21 +240,19 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   bootstrap (~> 5.0.2)
-  bootstrap-sass (= 3.4.1)
   capybara
-  cssbundling-rails
   debug
   importmap-rails
   jbuilder
   jquery-rails
-  pg (~> 1.1)
-  propshaft
+  pg (~> 1.4)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
   sass-rails
   selenium-webdriver
   simple_calendar (~> 2.0)
   sprockets-rails
+  sqlite3 (~> 1.4)
   stimulus-rails
   turbo-rails
   tzinfo-data


### PR DESCRIPTION
renderにデプロイする際にgemfileとgemfile.lockの差分でエラーが出ていると思われるので不要なコードを削除
