### PR TITLE
Change header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,18 @@ h1 {
   background-color: #ee7800;
 }
 
+.bg-blue {
+  background-color: #00CCFF;
+}
+
+.btn-green {
+  background-color: #53a034;
+}
+
+.text-color-gray-white {
+  color: #F5F5F5;
+}
+
 body {
   padding-top: 200px;
 }

--- a/app/views/diagnostics/index.html.erb
+++ b/app/views/diagnostics/index.html.erb
@@ -74,14 +74,8 @@
       </div>
 
     <% end %>
-    <% if logged_in? %>
-      <div class="col-12 text-right">
-        <%= link_to "戻る", current_user %>
-      </div>
-    <% else %>
-      <div class="col-12 text-right">
-        <%= link_to '戻る', '/' %>
-      </div>
-    <% end %>
+    <div class="col-12 text-right">
+      <%= link_to '戻る', '/' %>
+    </div>
   </div>
 </div>

--- a/app/views/diagnostics/index.html.erb
+++ b/app/views/diagnostics/index.html.erb
@@ -74,8 +74,14 @@
       </div>
 
     <% end %>
-    <div class="col-12 text-right">
-      <%= link_to '戻る', '/' %>
-    </div>
+    <% if logged_in? %>
+      <div class="col-12 text-right">
+        <%= link_to "戻る", current_user %>
+      </div>
+    <% else %>
+      <div class="col-12 text-right">
+        <%= link_to '戻る', '/' %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/diagnostics/show.html.erb
+++ b/app/views/diagnostics/show.html.erb
@@ -9,20 +9,20 @@
           平均と比較して<%= @count %>項目に問題がありました
         </h3>
         <h3 class="card-title py-3 row justify-content-center">
-          いますぐFinancial Plannerに相談しましょう!
+          いますぐファイナンシャルプランナーに相談しましょう!
         </h3>
       <% else %>
         <h3 class="card-title py-3  row justify-content-center">
           あなたの経済状況は素晴らしいです！！
         </h3>
         <h3 class="card-title py-3 row justify-content-center">
-          今後の不安を解決しませんか？Financial Plannerに相談しましょう!
+          今後の不安を解決しませんか？ファイナンシャルプランナーに相談しましょう!
         </h3>
       <% end %>
       <% if current_user%>
-        <%= link_to "reservation", reservations_index_path, class: 'btn btn-primary mx-auto d-block col-3' %>
+        <%= link_to "ファイナンシャルプランナーに相談する", reservations_index_path, class: 'btn btn-primary mx-auto d-block col-3' %>
       <% else %>
-        <%= link_to "sign up", signup_path, class: 'btn btn-primary mx-auto d-block col-3' %>
+        <%= link_to "会員登録を行う", signup_path, class: 'btn btn-primary mx-auto d-block col-3' %>
       <% end %>
     </div>
   </div>

--- a/app/views/financial_planners/new.html.erb
+++ b/app/views/financial_planners/new.html.erb
@@ -16,7 +16,7 @@
       <%= f.label :password_confirmation, "パスワードの再入力" %>
       <%= f.password_field :password_confirmation, class: 'form-control' %>
 
-      <%= f.submit "Create my account", class: "btn btn-primary" %>
+      <%= f.submit "この情報で登録を行う", class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,7 +36,7 @@
       <% end%>
       <% if financial_planner_logged_in?%>
         <li class="nav-item">
-          <%= link_to "勤怠登録", new_schedule_path , {:class => "nav-link text-color-gray-white"}%>
+          <%= link_to "相談枠の登録", new_schedule_path , {:class => "nav-link text-color-gray-white"}%>
         </li>
       <% end %>
     </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,39 +1,42 @@
-<nav class="navbar navbar-expand-sm bg-orange mb-3 container-fluid fixed-top d-flex justify-content-between">
+<nav class="navbar navbar-expand-sm mb-3 container-fluid fixed-top d-flex justify-content-between <%= financial_planner_logged_in? ? "bg-blue" : "bg-orange" %>">
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav4"
     aria-controls="navbarNav4" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
   <div>
     <% if logged_in? %>
-      <%= link_to "FP App", current_user, {:class => "nav-brand text-dark"}%>
+      <%= link_to "FP App", current_user, {:class => "nav-brand text-color-gray-white"}%>
     <% elsif financial_planner_logged_in?%>
-      <%= link_to "FP App", current_financial_planner, {:class => "nav-brand text-dark"}%>
+      <%= link_to "FP App", current_financial_planner, {:class => "nav-brand text-color-gray-white"}%>
     <% else %>
-      <a class="nav-link text-dark" href="/">FP App</a>
+      <a class="nav-link text-color-gray-white" href="/">FP App</a>
     <% end %>
   </div>
   <div class="justify-content-center header">
     <ul class="navbar-nav">
       <li class="nav-item active">
         <% if logged_in? %>
-          <%= link_to "ホーム", current_user, {:class => "nav-link text-dark"}%>
+          <%= link_to "ホーム", current_user, {:class => "nav-link text-color-gray-white"}%>
         <% elsif financial_planner_logged_in?%>
-          <%= link_to "ホーム", current_financial_planner, {:class => "nav-link text-dark"}%>
+          <%= link_to "ホーム", current_financial_planner, {:class => "nav-link text-color-gray-white"}%>
         <% else %>
-          <a class="nav-link text-dark" href="/">ホーム</a>
+          <a class="nav-link text-color-gray-white" href="/">ホーム</a>
         <% end %>
       </li>
-      <li class="nav-item">
-        <%= link_to "診断", diagnostics_index_path, {:class => "nav-link text-dark"}%>
-      </li>
+      <% if financial_planner_logged_in? %>
+      <% else %>
+        <li class="nav-item">
+          <%= link_to "診断", diagnostics_index_path, {:class => "nav-link text-color-gray-white"}%>
+        </li>
+      <% end %>
       <% if logged_in? %>
         <li class="nav-item">
-          <%= link_to "相談予約", reservations_index_path, {:class => "nav-link text-dark"}%>
+          <%= link_to "相談予約", reservations_index_path, {:class => "nav-link text-color-gray-white"}%>
         </li>
       <% end%>
       <% if financial_planner_logged_in?%>
         <li class="nav-item">
-          <%= link_to "勤怠登録", new_schedule_path , {:class => "nav-link text-dark"}%>
+          <%= link_to "勤怠登録", new_schedule_path , {:class => "nav-link text-color-gray-white"}%>
         </li>
       <% end %>
     </ul>
@@ -42,16 +45,16 @@
     <ul class="navbar-nav">
       <li class="nav-item active">
         <% if logged_in? %>
-          <li class="btn btn-success">
-            <%= link_to "ログアウト", logout_path, data: { "turbo-method": :delete } %>
+          <li class="btn btn-green">
+            <%= link_to "ログアウト", logout_path, data: { "turbo-method": :delete }, :class => "text-color-gray-white" %>
           </li>
         <% elsif financial_planner_logged_in? %>
-          <li class="btn btn-success">
-            <%= link_to "ログアウト", fplogout_path, data: { "turbo-method": :delete } %>
+          <li class="btn btn-green">
+            <%= link_to "ログアウト", fplogout_path, data: { "turbo-method": :delete }, :class => "text-color-gray-white" %>
           </li>
         <% else %>
-          <a class="btn btn-success" type="button" href="/login">個人向けログイン</a>
-          <a class="btn btn-success" type="button" href="/fplogin">FP向けログイン</a>
+          <a class="btn btn-green text-color-gray-white" type="button" href="/login">個人向けログイン</a>
+          <a class="btn btn-green text-color-gray-white" type="button" href="/fplogin">FP向けログイン</a>
         <% end %>
       </li>
     </ul>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h1>会員認証</h1>
+<h1>個人向けログイン</h1>
 
 <div class="row justify-content-center">
   <div class="col-md-6 col-md-offset-3">

--- a/app/views/shared/_schedule_error_messages.html.erb
+++ b/app/views/shared/_schedule_error_messages.html.erb
@@ -1,7 +1,7 @@
 <% if @schedule.errors.any? %>
   <div id="error_explanation">
     <div class="alert alert-danger">
-      The form contains <%= pluralize(@schedule.errors.count, "error") %>.
+      <%= @schedule.errors.count %>件のエラーが発生しました
     </div>
     <ul>
       <% @schedule.errors.full_messages.each do |msg| %>


### PR DESCRIPTION
### ヘッダーのデザインを変更しました

- FPの管理画面のヘッダーは青になるように変更しました
- ヘッダーの文字を白に統一しました
- ログイン、ログアウトボタンの色を黄緑に変更しました
<img width="1792" alt="スクリーンショット 2023-06-28 23 44 48" src="https://github.com/ryuryu5121/financial_planner_app/assets/67499913/7534f067-e426-41d8-ba20-8bc2e1599049">
<img width="1792" alt="スクリーンショット 2023-06-28 23 45 01" src="https://github.com/ryuryu5121/financial_planner_app/assets/67499913/4e957b10-84fe-4515-b86c-1ed1977ef0fd">
